### PR TITLE
Added image variants aliasing basic support

### DIFF
--- a/agents.jsonnet
+++ b/agents.jsonnet
@@ -17,6 +17,11 @@ local default = import "default.libsonnet";
           raw_dockerfile:: importstr "basic/Dockerfile",
         },
       },
+      variants+: default.addAliases(super.variants, [
+        "docker.io/eclipsecbijenkins/basic-agent:%s",
+        "docker.io/eclipsecbijenkins/jenkins-agent:%s",
+        "docker.io/eclipsecbi/jenkins-jnlp-agent:%s", 
+      ]),
     },
     default + {
       spec+: {
@@ -25,7 +30,13 @@ local default = import "default.libsonnet";
         docker+: {
           raw_dockerfile:: importstr "centos-7/Dockerfile",
         },
-      }
+      },
+      variants+: default.addAliases(super.variants, [ 
+        "docker.io/eclipsecbijenkins/jipp-migration-agent:%s", 
+        "docker.io/eclipsecbijenkins/migration-fat-agent:%s",
+        "docker.io/eclipsecbijenkins/ui-test-agent:%s",
+        "docker.io/eclipsecbijenkins/ui-tests-agent:%s", 
+      ]),
     },
   ]
 }

--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,14 @@ build_agent_variant() {
 
   INFO "Building docker image ${image}:${tag} (push=${PUSH_IMAGES})"
   dockerw build "${image}" "${tag}" "${config_dir}/Dockerfile" "${config_dir}" "${PUSH_IMAGES}" |& TRACE
+
+  for alias in $(jq -r '.docker.aliases[]' "${config}"); do 
+    INFO "Tagging docker image alias '${alias}' -> '${image}:${tag}' (push=${PUSH_IMAGES})"
+    docker tag "${image}:${tag}" "${alias}"
+    if [[ "${PUSH_IMAGES}" == "true" ]]; then
+      docker push "${alias}"
+    fi
+  done
 }
 
 build_agent_spec() {

--- a/build.sh
+++ b/build.sh
@@ -53,8 +53,10 @@ build_agent_variant() {
 
   for alias in $(jq -r '.docker.aliases[]' "${config}"); do 
     INFO "Tagging docker image alias '${alias}' -> '${image}:${tag}' (push=${PUSH_IMAGES})"
-    docker tag "${image}:${tag}" "${alias}"
     if [[ "${PUSH_IMAGES}" == "true" ]]; then
+      # we have to pull the image as dockerw build does not make it available. TODO: should be improved in #dockertools
+      docker pull "${image}:${tag}" 
+      docker tag "${image}:${tag}" "${alias}"
       docker push "${alias}"
     fi
   done

--- a/default.libsonnet
+++ b/default.libsonnet
@@ -71,6 +71,7 @@
         remoting: remoting,
         docker: $.spec.docker + {
           tag: "remoting-%s" % remoting.version,
+          aliases: [],
           dockerfile: $.spec.remoting_dockerfile % (
             $.spec + {
               from: "%s/%s/%s:%s" % [$.spec.docker.registry, $.spec.docker.repository, $.spec.docker.image, $.spec.docker.tag],
@@ -82,5 +83,15 @@
         },
       } for remoting in (import "remoting/remoting.jsonnet").releases
     ]
+  },
+
+  addAliases(superVariants, names):: {
+    [variant]+: superVariants[variant] + {
+      docker+: {
+        aliases+: [ 
+          name % superVariants[variant].remoting.version for name in names
+        ]
+      },
+    }, for variant in std.objectFields(superVariants)
   },
 }


### PR DESCRIPTION
It allows us to rename agent images (though we have to be careful to not break images in old repository/name).

We can then start a real deprecation process on old names (while still keeping them up to date). 