### PR TITLE
Added symlinks creation script

### DIFF
--- a/default.libsonnet
+++ b/default.libsonnet
@@ -20,6 +20,7 @@
     home: "/home/%s" % self.username,
     agentWorkdir: self.home + "/jenkins-agent",
     startupScript: "/usr/local/bin/jenkins-agent",
+    symlinksFile: "/usr/share/jenkins-agent/symlinks",
     maxHeap: "256m",
 
     docker: {

--- a/remoting/Dockerfile
+++ b/remoting/Dockerfile
@@ -11,17 +11,19 @@ FROM %(from)s
 # These environment variables will be used in the uid_entrypoint script from the parent image
 ENV USER_NAME="%(username)s"
 ENV HOME="%(home)s"
+ENV SYMLINKS_FILE="%(symlinksFile)s"
 
 VOLUME [ "%(home)s", ]
 WORKDIR "%(home)s"
-ENTRYPOINT [ "uid_entrypoint", "%(startupScript)s" ]
+ENTRYPOINT [ "uid_entrypoint", "/usr/local/bin/symbolic_links.sh", "%(startupScript)s" ]
 
 ADD "%(remotingJarUrl)s" "%(remotingJar)s" 
 ADD "%(startupScriptUrl)s" "%(startupScript)s"
+COPY "symbolic_links.sh" "/usr/local/bin/symbolic_links.sh"
 
 RUN chmod 755 "$(dirname "%(remotingJar)s")" \
   && chmod 644 "%(remotingJar)s" \
-  && chmod ug+rx "%(startupScript)s" \
-  && chgrp 0 "%(startupScript)s"
+  && chmod ug+rx "%(startupScript)s" "/usr/local/bin/symbolic_links.sh" \
+  && chgrp 0 "%(startupScript)s" "/usr/local/bin/symbolic_links.sh"
 
 USER 10001:0

--- a/remoting/symbolic_links.sh
+++ b/remoting/symbolic_links.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#*******************************************************************************
+# Copyright (c) 2020 Eclipse Foundation and others.
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Public License 2.0
+# which is available at http://www.eclipse.org/legal/epl-v20.html,
+# or the MIT License which is available at https://opensource.org/licenses/MIT.
+# SPDX-License-Identifier: EPL-2.0 OR MIT
+#*******************************************************************************
+
+# See http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit
+set -o nounset
+set -o pipefail
+
+IFS=$'\n\t'
+
+# export this variable with another value if another file should be used
+SYMLINKS_FILE="${SYMLINKS_FILE:-"/usr/share/jenkins-agent/symlinks"}"
+
+if [[ -f "${SYMLINKS_FILE}" ]]; then
+  while read -r symlink || [[ -n "${symlink}" ]]; do
+    #trim whitespaces
+    symlink="$(echo -e "${symlink}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    s=$(cut -d';' -f1 <<<"${symlink}")
+    t=$(cut -d';' -f2 <<<"${symlink}")
+    mkdir -p "$(dirname "${s}")"
+    if ln -s "${s}" "${t}"; then
+      >&2 echo "INFO: Created symlink from ${t} -> ${s}"
+    else
+      >&2 echo "WARNING: Cannot create symlink from ${t} -> ${s}"
+    fi
+  done < "${SYMLINKS_FILE}"
+else
+  >&2 echo "INFO: File ${SYMLINKS_FILE} does not exist."
+fi
+
+if [[ ${#} -ge 1 ]]; then
+  # another scripts has been requested to start after this one, execute it
+  exec "$@"
+fi


### PR DESCRIPTION
This is early work that will prevent projects from having to specify emptyDir volume mounts, e.g. for maven .m2/repository. 

Instead of mounting configmap/secrets subpath inside $HOME, we will mount them somewhere else on the FS (/var, /usr...). This script will be executed at agent startup and create symbolinc to files from config map / secrets. It could remove the need for a Kube mutating admission webhook (see eclipse-cbi/jiro#20)