### PR TITLE
Add package python3-devel for python header

### DIFF
--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -30,6 +30,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     mutter \
     pinentry \
     python3 \
+    python3-devel \
     rsync \
     tigervnc \
     tigervnc-server \


### PR DESCRIPTION
Allow to install with python cli.

```
python3 -m pip install --user -r requirements.txt
```

Current problem: 
 ```
src/_imagingtk.c:15:20: fatal error: Python.h: No such file or directory
```