### PR TITLE
Don't use base image for basic-ubuntu

### DIFF
--- a/basic-ubuntu/Dockerfile
+++ b/basic-ubuntu/Dockerfile
@@ -6,5 +6,26 @@
 # or the MIT License which is available at https://opensource.org/licenses/MIT.
 # SPDX-License-Identifier: EPL-2.0 OR MIT
 #*******************************************************************************
-FROM eclipsecbi/semeru-ubuntu-coreutils:openjdk11-jammy
+ARG FROM_TAG="open-17-jdk-jammy"
+FROM ibm-semeru-runtimes:${FROM_TAG}
+
+RUN apt-get update && apt-get install -y software-properties-common \
+  && add-apt-repository -y ppa:git-core/ppa
+
+RUN apt-get upgrade -y && apt-get install -y --no-install-recommends \
+  bash \
+  coreutils \
+  curl \
+  dumb-init \
+  git \
+  git-lfs \
+  gnupg \
+  jq \
+  openssh-client \
+  rsync \
+  fonts-dejavu \
+  unzip \
+  wget \
+  zip
+
 RUN ln -sf /bin/bash /bin/sh

--- a/basic-ubuntu/README.md
+++ b/basic-ubuntu/README.md
@@ -2,11 +2,11 @@
 
 | OS / Tool | Version |
 | -----------------|---------|
-| OS release <br> (cat /etc/issue) | Ubuntu 22.04.2 LTS \n \l |
-| Java | openjdk version "11.0.17" 2022-10-18<br>IBM Semeru Runtime Open Edition 11.0.17.0 (build 11.0.17+8)<br>Eclipse OpenJ9 VM 11.0.17.0 (build openj9-0.35.0, JRE 11 Linux amd64-64-Bit Compressed References 20221031_559 (JIT enabled, AOT enabled)<br>OpenJ9   - e04a7f6c1<br>OMR      - 85a21674f<br>JCL      - a94c231303 based on jdk-11.0.17+8) |
-| Git | git version 2.39.2 |
-| SSH | OpenSSH_8.9p1 Ubuntu-3ubuntu0.1, OpenSSL 3.0.2 15 Mar 2022 |
+| OS release <br> (cat /etc/issue) | Ubuntu 22.04.3 LTS \n \l |
+| Java | openjdk version "11.0.21" 2023-10-17<br>IBM Semeru Runtime Open Edition 11.0.21.0 (build 11.0.21+9)<br>Eclipse OpenJ9 VM 11.0.21.0 (build openj9-0.41.0, JRE 11 Linux amd64-64-Bit Compressed References 20231122_912 (JIT enabled, AOT enabled)<br>OpenJ9   - 461bf3c70<br>OMR      - 5eee6ad9d<br>JCL      - 0fd7a05277 based on jdk-11.0.21+9) |
+| Git | git version 2.43.0 |
+| SSH | OpenSSH_8.9p1 Ubuntu-3ubuntu0.5, OpenSSL 3.0.2 15 Mar 2022 |
 | bash | GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu) |
 | Wget | GNU Wget 1.21.2 built on linux-gnu. |
-| cURL | curl 7.81.0 (x86_64-pc-linux-gnu) libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.13 |
+| cURL | curl 7.81.0 (x86_64-pc-linux-gnu) libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.16 |
 | GPG | gpg (GnuPG) 2.2.27 |


### PR DESCRIPTION
- Use JDK17 by default