### PR TITLE
Update centos images

### DIFF
--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -8,12 +8,17 @@
 #*******************************************************************************
 FROM eclipsecbi/centos:7
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+
 # ius-release required for python36u
-RUN yum install -y \
+RUN yum upgrade -y \
+  && yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-  yum install -y --setopt=skip_missing_names_on_install=False \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+  && yum install -y --setopt=skip_missing_names_on_install=False \
     autoconf \
     automake \
     boost-test \

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -13,7 +13,8 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
   && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # See https://fedoraproject.org/wiki/EPEL
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+RUN dnf upgrade -y \
+  && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
   && dnf install -y https://opensource.wandisco.com/centos/8/git/x86_64/wandisco-git-release-8-1.noarch.rpm \
   && dnf install -y 'dnf-command(config-manager)' \
   && dnf config-manager --set-enabled powertools \


### PR DESCRIPTION
Since 1st July, centos 7 mirrors are no longer available. 

This PR : 
* Apply a patch to change default mirror URL for centos 7
* Update all packages for centos 7 and 8 due to the removal of the base image build in eclipsecbi: https://github.com/eclipse-cbi/dockerfiles/commit/743d0768e1cd00c49f4a4b99fe8ea54428345f40
