### PR TITLE
Avoid creating directory '/home/jenkins,' with a comma

### DIFF
--- a/remoting-uidentrypoint/Dockerfile
+++ b/remoting-uidentrypoint/Dockerfile
@@ -12,7 +12,7 @@ FROM %(from)s
 ENV USER_NAME="%(username)s"
 ENV HOME="%(home)s"
 
-VOLUME [ "%(home)s", ]
+VOLUME [ "%(home)s" ]
 WORKDIR "%(home)s"
 ENTRYPOINT [ "uid_entrypoint", "%(startupScript)s" ]
 

--- a/remoting/Dockerfile
+++ b/remoting/Dockerfile
@@ -12,7 +12,7 @@ FROM %(from)s
 ENV USER_NAME="%(username)s"
 ENV HOME="%(home)s"
 
-VOLUME [ "%(home)s", ]
+VOLUME [ "%(home)s" ]
 WORKDIR "%(home)s"
 ENTRYPOINT [ "%(startupScript)s" ]
 


### PR DESCRIPTION
Avoid dir '/home/jenkins,' compare to '/home/jenkins'

![image](https://github.com/user-attachments/assets/68143853-5ab4-4cb1-8782-d82485475f2d)
